### PR TITLE
Transducer-friendly reading

### DIFF
--- a/src/main/clojure/clojure/data/csv.clj
+++ b/src/main/clojure/clojure/data/csv.clj
@@ -172,14 +172,15 @@
 		({:lf "\n" :cr+lf "\r\n"} newline))))
 
 (defn lines-reducible
+  "A reducible alternative to `line-seq`."
   [^BufferedReader rdr]
   (reify IReduceInit
-    (reduce [ this f init]
+    (reduce [this f init]
       (with-open [r rdr]
         (loop [state init]
           (if (reduced? state)
             @state
-            (if-let [line (.readLine rdr)]
+            (if-let [line (.readLine r)]
               (recur (f state line))
               state)))))))
 

--- a/src/test/clojure/clojure/data/csv_test.clj
+++ b/src/test/clojure/clojure/data/csv_test.clj
@@ -1,8 +1,8 @@
 (ns clojure.data.csv-test
   (:use
     [clojure.java.io :only (reader)]
-    [clojure.test :only (deftest is)]
-    [clojure.data.csv :only (read-csv write-csv lines-reducible)])
+    [clojure.test :only (deftest is testing)]
+    [clojure.data.csv :only (read-csv write-csv lines-reducible rows->maps rows->maps-xform)])
   (:require [clojure.string :as str])
   (:import
     [java.io Reader StringReader StringWriter EOFException]))
@@ -26,7 +26,7 @@
 1996,Jeep,Grand Cherokee,\"MUST SELL!
 air, moon roof, loaded\",4799.00")
 
-(def ^{:private true} complicated-no-newlines
+(def ^{:private true} complicated-no-newlines ;; for testing reducible input
   "1997,Ford,E350,\"ac, abs, moon\",3000.00
 1999,Chevy,\"Venture \"\"Extended Edition\"\"\",\"\",4900.00
 1999,Chevy,\"Venture \"\"Extended Edition, Very Large\"\"\",\"\",5000.00
@@ -88,14 +88,6 @@ air, moon roof, loaded\",4799.00")
                ["1996" "jeep" "grand cherokee", "must sell!,air, moon roof, loaded" "4799.00"])))
 
       ))
-
-
-
-
-
-
-
-
   )
         
 
@@ -132,3 +124,39 @@ air, moon roof, loaded\",4799.00")
     (is (= 2 (count csv)))
     (is (= ["Year" "Make" "Model"] (first csv)))
     (is (= ["1997" "Ford" "E350"] (second csv)))))
+
+
+(deftest rows->maps-tests
+  (let [expected [{:foo "A"
+                   :bar "1"
+                   :baz "x"}
+                  {:foo "B"
+                   :bar "2"
+                   :baz "y"}
+                  {:foo "C"
+                   :bar "3"
+                   :baz "z"}]]
+    (testing "lazy version"
+      (time
+        (let [sample "foo,bar,baz\nA,1,x\nB,2,y\nC,3,z"
+              csv (read-csv sample)]
+          (is (= expected (rows->maps csv))))))
+
+    (testing "eager version"
+      (time
+        (let [sample "A,1,x\nB,2,y\nC,3,z"
+              lines (lines-reducible
+                      (reader (StringReader. sample)))
+              headers ["foo" "bar" "baz"]]
+          (is (= expected
+                 (read-csv lines :xform (rows->maps-xform headers))))))
+      )
+    )
+
+
+
+
+
+
+
+  )

--- a/src/test/clojure/clojure/data/csv_test.clj
+++ b/src/test/clojure/clojure/data/csv_test.clj
@@ -60,7 +60,7 @@ air, moon roof, loaded\",4799.00")
 
       (let [lines (lines-reducible
                     (reader (StringReader. simple)))
-            csv (read-csv lines :xform (map uncapitalize))]
+            csv (into [] (map uncapitalize) (read-csv lines))]
         (is (= (count csv) 3))
         (is (= (count (first csv)) 3))
         (is (= (first csv) ["year" "make" "model"]))
@@ -68,9 +68,9 @@ air, moon roof, loaded\",4799.00")
 
       (let [lines (lines-reducible
                     (reader (StringReader. simple-alt-sep)))
-            csv (read-csv lines
-                          :separator \;
-                          :xform (map uncapitalize))]
+            csv (into []
+                      (map uncapitalize)
+                      (read-csv lines :separator \;))]
         (is (= (count csv) 3))
         (is (= (count (first csv)) 3))
         (is (= (first csv) ["year" "make" "model"]))
@@ -79,7 +79,7 @@ air, moon roof, loaded\",4799.00")
       ;; can't deal with newlines through this path :(
       (let [lines (lines-reducible
                     (reader (StringReader. complicated-no-newlines)))
-            csv (read-csv lines :xform (map uncapitalize))]
+            csv (into [] (map uncapitalize) (read-csv lines))]
         (is (= (count csv) 4))
         (is (= (count (first csv)) 5))
         (is (= (first csv)
@@ -149,7 +149,9 @@ air, moon roof, loaded\",4799.00")
                       (reader (StringReader. sample)))
               headers ["foo" "bar" "baz"]]
           (is (= expected
-                 (read-csv lines :xform (rows->maps-xform headers))))))
+                 (into []
+                       (rows->maps-xform headers)
+                       (read-csv lines))))))
       )
     )
 

--- a/src/test/clojure/clojure/data/csv_test.clj
+++ b/src/test/clojure/clojure/data/csv_test.clj
@@ -127,7 +127,8 @@ air, moon roof, loaded\",4799.00")
 
 
 (deftest rows->maps-tests
-  (let [expected [{:foo "A"
+  (let [sample "foo,bar,baz\nA,1,x\nB,2,y\nC,3,z"
+        expected [{:foo "A"
                    :bar "1"
                    :baz "x"}
                   {:foo "B"
@@ -138,19 +139,18 @@ air, moon roof, loaded\",4799.00")
                    :baz "z"}]]
     (testing "lazy version"
       (time
-        (let [sample "foo,bar,baz\nA,1,x\nB,2,y\nC,3,z"
-              csv (read-csv sample)]
+        (let [csv (read-csv sample)]
           (is (= expected (rows->maps csv))))))
 
     (testing "eager version"
       (time
-        (let [sample "A,1,x\nB,2,y\nC,3,z"
-              lines (lines-reducible
+        (let [lines (lines-reducible
                       (reader (StringReader. sample)))
               headers ["foo" "bar" "baz"]]
           (is (= expected
                  (into []
-                       (rows->maps-xform headers)
+                       (comp (drop 1)
+                             (rows->maps-xform headers))
                        (read-csv lines))))))
       )
     )


### PR DESCRIPTION
Extended the core protocol to `IReduceInit`, and the implementation returns an `eduction`. Also added a couple of helpers, notably the `lines-reducible` fn whose result is what we expect will be passed to the `IReduceInit` implementation 99% of the times. Tests have been expanded too. 

**CAVEAT**: 
Newline characters (inside quoted cells) cannot possibly work down this path, so technically I'm breaking compliance here. That said, all the CSV files that I've ever worked with (and I suspect the vast majority of CSV data out there) are not that fancy (i.e. they don't contain newlines in quoted-cells). So as long as that particular limitation is well documented, I can see this protocol extension being rather useful.   