### PR TITLE
Make clojure.data.csv/write-csv thread-safe

### DIFF
--- a/src/main/clojure/clojure/data/csv.clj
+++ b/src/main/clojure/clojure/data/csv.clj
@@ -10,7 +10,7 @@
       :doc "Reading and writing comma separated values."}
   clojure.data.csv
   (:require (clojure [string :as str]))
-  (:import (java.io PushbackReader Reader Writer StringReader EOFException)))
+  (:import (java.io PushbackReader Reader Writer StringReader EOFException StringWriter)))
 
 ;(set! *warn-on-reflection* true)
 
@@ -120,8 +120,10 @@
   [^Writer writer records sep quote quote? ^String newline]
   (loop [records records]
     (when-first [record records]
-      (write-record writer record sep quote quote?)
-      (.write writer newline)
+      (let [str-writer (StringWriter.)]
+        (write-record str-writer record sep quote quote?)
+        (.write str-writer newline)
+        (.write writer (.toString str-writer)))
       (recur (next records)))))
 
 (defn write-csv

--- a/src/test/clojure/clojure/data/csv_test.clj
+++ b/src/test/clojure/clojure/data/csv_test.clj
@@ -77,3 +77,12 @@ air, moon roof, loaded\",4799.00")
     (is (= 2 (count csv)))
     (is (= ["Year" "Make" "Model"] (first csv)))
     (is (= ["1997" "Ford" "E350"] (second csv)))))
+
+
+(deftest write-from-multiple-threads
+  (let [string-writer (StringWriter.)
+        futures (mapv #(future (write-csv string-writer [[% %]]))
+                      (range 10))]
+    (mapv deref futures)
+    (is (= (set (read-csv (.toString string-writer)))
+           (set (map (juxt str str) (range 10)))))))


### PR DESCRIPTION
For each record, write the output to a StringWriter and then write
that to the file. Reason: Multiple calls to .write on the file writer
makes write-csv non thread-safe.